### PR TITLE
Wordlist option for the brute sub command

### DIFF
--- a/knxmap/core.py
+++ b/knxmap/core.py
@@ -115,7 +115,7 @@ class KnxMap(object):
                         LOGGER.error('Key {} is not a valid hex value'.format(line))                
         elif full_key_space:
             key_space = range(0, 0xffffffff)
-        else:            
+        else:
             key_space = [0x11223344, 0x12345678, 0x00000000, 0x87654321, 0x11111111, 0xffffffff]
 
         # Bruteforce the key via A_Authorize_Request messages

--- a/knxmap/core.py
+++ b/knxmap/core.py
@@ -93,7 +93,7 @@ class KnxMap(object):
         return self.bus_queues[gateway]
 
     @asyncio.coroutine
-    def bruteforce_auth_key(self, knx_gateway, target, full_key_space=False):
+    def bruteforce_auth_key(self, knx_gateway, target, full_key_space=False, wordlist=None):
         if isinstance(target, set):
             target = list(target)[0]
         future = asyncio.Future()
@@ -104,10 +104,20 @@ class KnxMap(object):
         # Make sure the tunnel has been established
         connected = yield from future
         alive = yield from protocol.tpci_connect(target)
-        if full_key_space:
+        if wordlist: 
+            key_space = []
+            with open(wordlist, 'r') as f:
+                for line in f.readlines():
+                    line = line.rstrip()                   
+                    try: 
+                        key_space.append(int('0x' + line, 0))
+                    except ValueError: 
+                        LOGGER.error('Key {} is not a valid hex value'.format(line))                
+        elif full_key_space:
             key_space = range(0, 0xffffffff)
-        else:
+        else:            
             key_space = [0x11223344, 0x12345678, 0x00000000, 0x87654321, 0x11111111, 0xffffffff]
+
         # Bruteforce the key via A_Authorize_Request messages
         for key in key_space:
             access_level = yield from protocol.apci_authenticate(target, key)
@@ -328,10 +338,10 @@ class KnxMap(object):
         LOGGER.info('Searching done')
 
     @asyncio.coroutine
-    def brute(self, targets=None, bus_target=None, full_key_space=False):
+    def brute(self, targets=None, bus_target=None, full_key_space=False, wordlist=None):
         if targets:
             self.set_targets(targets)
-        tasks = [asyncio.Task(self.bruteforce_auth_key(t, bus_target, full_key_space),
+        tasks = [asyncio.Task(self.bruteforce_auth_key(t, bus_target, full_key_space, wordlist),
                               loop=self.loop) for t in self.targets]
         yield from asyncio.wait(tasks)
 

--- a/knxmap/main.py
+++ b/knxmap/main.py
@@ -168,6 +168,9 @@ pbrute.add_argument(
 pbrute.add_argument(
     '--full-key-space', action='store_true', dest='full_key_space',
     default=False, help='bruteforce the full key space (0 - 0xffffffff)')
+pbrute.add_argument(
+    '--wordlist', default=None, help='Wordlist of keys in hex')
+
 
 pmonitor = SUBARGS.add_parser('monitor', help='Monitor bus and group messages',
                               formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -230,7 +233,8 @@ def main():
             bus_target = KnxTargets(args.bus_target)
             loop.run_until_complete(knxmap.brute(
                 bus_target=bus_target.targets,
-                full_key_space=args.full_key_space))
+                full_key_space=args.full_key_space,
+                wordlist=args.wordlist))
         elif args.cmd == 'scan':
             LOGGER.info('Scanning {} target(s)'.format(len(targets.targets)))
             bus_targets = KnxTargets(args.bus_targets)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -83,7 +83,8 @@ class BasicTests(unittest.TestCase):
         try:
             self.loop.run_until_complete(self.knxmap.brute(
                 bus_target=bus_targets.targets,
-                full_key_space=False))
+                full_key_space=False,
+                wordlist=None))
         except KnxTunnelException as e:
             self.fail(e.message)
 


### PR DESCRIPTION
Hi, 

This commit extends the brute sub command to read BCU keys from a file. Needed that feature for the recovery of BCU keys from a memory dump of a controller

